### PR TITLE
Variable file size from URL parameter maxFileSize

### DIFF
--- a/core/src/main/java/gwtupload/server/UploadServlet.java
+++ b/core/src/main/java/gwtupload/server/UploadServlet.java
@@ -48,6 +48,7 @@ import javax.servlet.http.HttpSession;
 
 import static gwtupload.shared.UConsts.MULTI_SUFFIX;
 import static gwtupload.shared.UConsts.PARAM_DELAY;
+import static gwtupload.shared.UConsts.PARAM_MAX_FILE_SIZE;
 import static gwtupload.shared.UConsts.TAG_BLOBSTORE;
 import static gwtupload.shared.UConsts.TAG_BLOBSTORE_PATH;
 import static gwtupload.shared.UConsts.TAG_CANCELED;
@@ -904,6 +905,8 @@ public class UploadServlet extends HttpServlet implements Servlet {
 
     try {
       String delay = request.getParameter(PARAM_DELAY);
+      String maxFilesize = request.getParameter(PARAM_MAX_FILE_SIZE);
+      maxSize = maxFilesize != null && maxFilesize.matches("[0-9]*") ? Long.parseLong(maxFilesize) : maxSize;
       uploadDelay = Integer.parseInt(delay);
     } catch (Exception e) { }
 

--- a/core/src/main/java/gwtupload/shared/UConsts.java
+++ b/core/src/main/java/gwtupload/shared/UConsts.java
@@ -51,4 +51,5 @@ public class UConsts {
   public static final String MULTI_SUFFIX = "[]";
 
   public static final String RESP_OK = "ok";
+  public static final String PARAM_MAX_FILE_SIZE = "maxFileSize";
 }


### PR DESCRIPTION
gwt-upload currently allows predefined file size in web.xml . For our project requirement I modified the gwt-upload code for variable file size on each request. However we've server-side validation for file size to control the random and big files.